### PR TITLE
Add a path rewrite for /se/file to /file

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -198,6 +198,10 @@ func (app *App) HandleProxy(w http.ResponseWriter, r *http.Request) {
 		done <- cancel
 	}()
 
+	seUploadPath, uploadPath := "/se/file", "/file"
+	if strings.HasSuffix(r.URL.Path, seUploadPath) {
+		r.URL.Path = strings.TrimSuffix(r.URL.Path, seUploadPath) + uploadPath
+	}
 	fragments := strings.Split(r.URL.Path, "/")
 	vars := mux.Vars(r)
 	id, ok := vars["sessionId"]


### PR DESCRIPTION
Selenium grid 4 specced clients send /se/file, selenoid handles this in their proxy layer, so we need to as well.