### PR TITLE
Add MCP (Model Context Protocol) sidecar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Seleniferous exposes Selenium-compatible endpoints on `/session` and internal pr
 | `POST` | `/session` | Create a new WebDriver session (proxied to local browser). |
 | `*` | `/session/{sessionId}/*` | Proxy all session traffic (HTTP and WebSocket). |
 | `WS` | `/playwright` | Proxies WS traffic. |
+| `POST` | `/mcp` | MCP Streamable HTTP transport — client requests (proxied to local browser `/mcp`). |
+| `GET` | `/mcp` | MCP Streamable HTTP transport — server-initiated messages (proxied to local browser `/mcp`). |
+| `DELETE` | `/mcp` | Terminate the MCP session; schedules browser teardown. |
 | `*` | `/selenosis/v1/sessions/{sessionId}/proxy/http/*` | Internal HTTP proxy used by Selenosis. |
 | `GET` | `/selenosis/v1/vnc/{sessionId}` | Internal VNC proxy used by Selenosis. |
 
@@ -106,6 +109,23 @@ A request to `/selenosis/v1/sessions/<sessionId>/proxy/http/json?file=somefile.t
 
 Multiple rules are evaluated in order; the first match is used.
 
+## MCP (experimental)
+
+Seleniferous proxies [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) **Streamable HTTP** traffic to an MCP server running inside the browser container on `BROWSER_PORT`. It is exposed on a single endpoint `/mcp` (`POST`, `GET`, `DELETE`).
+
+Sessions are identified by the `Mcp-Session-Id` header, which must equal the pod-derived UUID (`IPUUID`).
+
+- **Initialize** — `POST /mcp` without `Mcp-Session-Id` starts the upstream MCP session. Seleniferous stores the mapping `IPUUID -> <browser session id>` and returns `IPUUID` to the client in the `Mcp-Session-Id` response header. Only one MCP session per pod is allowed.
+- **Proxied requests** — `POST`/`GET /mcp` with `Mcp-Session-Id: <IPUUID>` are forwarded to `/mcp` on the browser. Seleniferous rewrites the header to the real browser session id on the way in, and back to `IPUUID` on the way out.
+- **Terminate** — `DELETE /mcp` ends the session and schedules teardown of the browser pod.
+
+Error responses for non-initialize requests:
+
+- a missing `Mcp-Session-Id` header returns **`400`**;
+- a header that does not match the pod `IPUUID`, or whose MCP session is not in the store, returns **`404`** so the client can `initialize` a fresh session.
+
+Request and response **bodies** are forwarded unchanged; only the `Mcp-Session-Id` header is rewritten. Each MCP request resets the session idle timeout, same as Selenium and Playwright traffic.
+
 ## Networking and headers
 If you run behind a reverse proxy or ingress, set these headers so Seleniferous can build correct external URLs:
 - `X-Forwarded-Proto`
@@ -120,12 +140,14 @@ The project is built and packaged entirely via Docker. Local Go installation is 
 
 The build process is controlled via the following Makefile variables:
 
-Variable	Description
-- BINARY_NAME	Name of the produced binary (seleniferous).
-- REGISTRY	Docker registry prefix (default: localhost:5000).
-- IMAGE_NAME	Full image name (<registry>/seleniferous).
-- VERSION	Image version/tag (default: develop).
-- PLATFORM	Target platform (default: linux/amd64).
-- CONTAINER_TOOL docker cmd
+| Variable         | Description                                                  |
+|------------------|--------------------------------------------------------------|
+| `BINARY_NAME`    | Name of the produced binary (fixed: `seleniferous`)         |
+| `REGISTRY`       | Docker registry prefix (default: `localhost:5000`)           |
+| `IMAGE_NAME`     | Full image name, derived as `$(REGISTRY)/$(BINARY_NAME)`     |
+| `VERSION`        | Image version/tag (default: `develop`)                       |
+| `EXTRA_TAGS`     | Additional `-t` tags passed to `docker-push` (default: none) |
+| `PLATFORM`       | Target platform (default: `linux/amd64`)                     |
+| `CONTAINER_TOOL` | Container build tool (default: `docker`)                     |
 
-REGISTRY, VERSION is expected to be provided externally, which allows the same Makefile to be used locally and in CI.
+`REGISTRY` and `VERSION` are expected to be provided externally, which allows the same Makefile to be used locally and in CI.

--- a/cmd/seleniferous/main.go
+++ b/cmd/seleniferous/main.go
@@ -78,6 +78,10 @@ func main() {
 
 	router.With(createTimeoutMiddleWare).Get("/playwright", svc.ProxyPlaywright)
 
+	router.With(createTimeoutMiddleWare).Post("/mcp", svc.ProxyMcp)
+	router.With(createTimeoutMiddleWare).Get("/mcp", svc.ProxyMcp)
+	router.With(createTimeoutMiddleWare).Delete("/mcp", svc.ProxyMcp)
+
 	router.Route("/selenosis/v1", func(r chi.Router) {
 		r.Route("/sessions/{sessionId}/proxy", func(r chi.Router) {
 			r.HandleFunc("/http/*", svc.RouteHTTP)

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 require github.com/gorilla/websocket v1.5.3
 
 require (
-	github.com/alcounit/browser-controller v0.0.6
-	github.com/alcounit/browser-service v0.0.6
+	github.com/alcounit/browser-controller v0.0.8
+	github.com/alcounit/browser-service v0.0.7
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/google/uuid v1.6.0
 	github.com/rs/zerolog v1.34.0
@@ -14,7 +14,7 @@ require (
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
-	github.com/alcounit/selenosis/v2 v2.0.6
+	github.com/alcounit/selenosis/v2 v2.0.8
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	golang.org/x/sys v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
-github.com/alcounit/browser-controller v0.0.6 h1:EJ7WAgxIwrn4DTpNVET/L67+WhRQDduSuHAMxcPw4gg=
-github.com/alcounit/browser-controller v0.0.6/go.mod h1:tpj7lwi2UJ49xt/vnEsZKAu5HAvtQJ7xbbcJO3wn+dc=
-github.com/alcounit/browser-service v0.0.6 h1:cDfYNPIOSzMKWgWOBwbhg3UH8JtL4aNj5vrj5uxJCd0=
-github.com/alcounit/browser-service v0.0.6/go.mod h1:el3dWyMLDd/bT2vyC6Zcsl8P5u9QmZmaTf9RFp7O1+k=
-github.com/alcounit/selenosis/v2 v2.0.6 h1:DVorTMMZJ79nJrGDlDkcdMu1li7woIqyA3ygteNgscU=
-github.com/alcounit/selenosis/v2 v2.0.6/go.mod h1:wZpGUIyNyL6Ux+xQypf3Vnzi34IlM6XV6cjDs7IvEy8=
+github.com/alcounit/browser-controller v0.0.8 h1:hauzkisDiUsGoIKUoQqvBmi4/MrixzGp55PnZIUA6rY=
+github.com/alcounit/browser-controller v0.0.8/go.mod h1:tpj7lwi2UJ49xt/vnEsZKAu5HAvtQJ7xbbcJO3wn+dc=
+github.com/alcounit/browser-service v0.0.7 h1:Pv33j3QrtjZaa4QxoohzCGn1urJ20kiMLgDwKeg1y1Q=
+github.com/alcounit/browser-service v0.0.7/go.mod h1:Oozpap9DWLAu2ViuJua5Q9KHXziVZUUFhacC//SVlXw=
+github.com/alcounit/selenosis/v2 v2.0.8 h1:vv2oM1diZB78xdNzpd1w2zrzfeBQc7GyzCGD0e20ats=
+github.com/alcounit/selenosis/v2 v2.0.8/go.mod h1:1hiSF5IDj9Zh7PuOetmk3+W6m9KJQbFp1FFzwfi/e2k=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
 github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/service/service.go
+++ b/service/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/alcounit/seleniferous/v2/pkg/pathutils"
 	"github.com/alcounit/seleniferous/v2/pkg/session"
 	"github.com/alcounit/seleniferous/v2/pkg/store"
+	"github.com/alcounit/selenosis/v2/pkg/jsonrpc"
 	"github.com/alcounit/selenosis/v2/pkg/proxy"
 	"github.com/alcounit/selenosis/v2/pkg/proxy/rule"
 	"github.com/alcounit/selenosis/v2/pkg/selenium"
@@ -33,14 +34,21 @@ var (
 
 	dialTCP = net.Dial
 
-	errorHandler = func(rw http.ResponseWriter, req *http.Request, err error) {
+	defaultErrorHandler = func(rw http.ResponseWriter, req *http.Request, err error) {
 		log := logctx.FromContext(req.Context())
 		log.Err(err).Msg("proxy error")
 
 		rw.WriteHeader(http.StatusInternalServerError)
 	}
 
-	localHost = "localhost"
+	mcpErrorHandler = func(rw http.ResponseWriter, req *http.Request, err error) {
+		log := logctx.FromContext(req.Context())
+		log.Err(err).Msg("mcp proxy error")
+		jsonrpc.WriteError(rw, http.StatusInternalServerError, jsonrpc.InternalError, "Internal error")
+	}
+
+	loopbackAddr = "127.0.0.1"
+	localhost    = "localhost"
 
 	defaultSleepTimeout       = 3 * time.Second
 	defaultSessionWaitTimeout = 10 * time.Second
@@ -76,27 +84,29 @@ func (s *Service) CreateSession(rw http.ResponseWriter, req *http.Request) {
 
 	if s.store.Len() > 0 {
 		log.Err(errSessionCreate).Msg("session already started")
-		writeErrorResponse(rw, http.StatusBadRequest, errSessionCreate)
+		writeErrorResponse(rw, http.StatusBadRequest, selenium.ErrSessionNotCreated(errSessionCreate))
 		return
 	}
 
+	s.manager.Touch(s.config.IPUUID)
+
 	if req.Body == nil {
 		log.Err(errSessionCreate).Msg("request body is nil")
-		writeErrorResponse(rw, http.StatusBadRequest, errSessionCreate)
+		writeErrorResponse(rw, http.StatusBadRequest, selenium.ErrInvalidArgument(errSessionCreate))
 		return
 	}
 
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Err(errSessionCreate).Msg("failed to read request body")
-		writeErrorResponse(rw, http.StatusBadRequest, errSessionCreate)
+		writeErrorResponse(rw, http.StatusBadRequest, selenium.ErrInvalidArgument(errSessionCreate))
 		return
 	}
 
 	var caps selenium.Capabilities
 	if err := json.Unmarshal(body, &caps); err != nil {
 		log.Err(err).Msg("failed to decode request body")
-		writeErrorResponse(rw, http.StatusBadRequest, errSessionCreate)
+		writeErrorResponse(rw, http.StatusBadRequest, selenium.ErrInvalidArgument(errSessionCreate))
 		return
 	}
 
@@ -104,19 +114,19 @@ func (s *Service) CreateSession(rw http.ResponseWriter, req *http.Request) {
 	body, err = json.Marshal(caps)
 	if err != nil {
 		log.Err(err).Msg("failed to encode request body")
-		writeErrorResponse(rw, http.StatusInternalServerError, errSessionCreate)
+		writeErrorResponse(rw, http.StatusInternalServerError, selenium.ErrSessionNotCreated(errSessionCreate))
 		return
 	}
 
 	url := &url.URL{
 		Scheme: "http",
-		Host:   net.JoinHostPort(localHost, s.config.BrowserPort),
+		Host:   net.JoinHostPort(loopbackAddr, s.config.BrowserPort),
 		Path:   req.URL.Path,
 	}
 
 	if err := wait(url.String(), s.config.SessionCreateTimeout); err != nil {
 		log.Err(err).Msg("browser service unavailable")
-		writeErrorResponse(rw, http.StatusServiceUnavailable, err)
+		writeErrorResponse(rw, http.StatusServiceUnavailable, selenium.Error("browser service unavailable", err))
 		return
 	}
 
@@ -144,7 +154,7 @@ func (s *Service) CreateSession(rw http.ResponseWriter, req *http.Request) {
 		}
 
 		if r.Body == nil {
-			log.Err(errSessionCreate).Msg("response body is empty, session not created")
+			log.Err(errSessionCreate).Int("statusCode", r.StatusCode).Msg("response body is empty, session not created")
 			r.Body = io.NopCloser(bytes.NewReader(nil))
 			notifyError(s.broadcaster, "response body is empty", errSessionCreate)
 			return errSessionCreate
@@ -152,7 +162,7 @@ func (s *Service) CreateSession(rw http.ResponseWriter, req *http.Request) {
 
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			log.Err(err).Msg("failed to read response body")
+			log.Err(err).Int("statusCode", r.StatusCode).Msg("failed to read response body")
 			notifyError(s.broadcaster, "failed to read response body", err)
 			return err
 		}
@@ -160,20 +170,20 @@ func (s *Service) CreateSession(rw http.ResponseWriter, req *http.Request) {
 
 		var response selenium.Payload
 		if err := json.Unmarshal(body, &response); err != nil {
-			log.Err(err).Msg("failed to decode response body")
+			log.Err(err).Int("statusCode", r.StatusCode).Msg("failed to decode response body")
 			notifyError(s.broadcaster, "failed to decode response body", err)
 			return err
 		}
 
 		originalSessionId, ok := response.GetSessionId()
 		if !ok {
-			log.Err(errSessionNotFound).Msg("response sessionId not found")
+			log.Err(errSessionNotFound).Int("statusCode", r.StatusCode).Msg("response sessionId not found")
 			notifyError(s.broadcaster, "response sessionId not found", errSessionNotFound)
 			return errSessionCreate
 		}
 
 		if ok := response.UpdateSessionId(s.config.IPUUID); !ok {
-			log.Err(errSessionCreate).Msg("failed to update sessionId in response")
+			log.Err(errSessionCreate).Int("statusCode", r.StatusCode).Msg("failed to update sessionId in response")
 			notifyError(s.broadcaster, "failed to update sessionId in response", errSessionCreate)
 			return errSessionCreate
 		}
@@ -185,7 +195,7 @@ func (s *Service) CreateSession(rw http.ResponseWriter, req *http.Request) {
 
 		body, err = json.Marshal(response)
 		if err != nil {
-			log.Err(err).Msg("failed to encode response body")
+			log.Err(err).Int("statusCode", r.StatusCode).Msg("failed to encode response body")
 			notifyError(s.broadcaster, "failed to encode response body", err)
 			return err
 		}
@@ -193,14 +203,14 @@ func (s *Service) CreateSession(rw http.ResponseWriter, req *http.Request) {
 		s.storeSessionId(originalSessionId)
 		s.manager.Touch(s.config.IPUUID)
 
-		log.Info().Str("originalSessionId", originalSessionId).Str("fakeSessionId", s.config.IPUUID).Msg("session id rewritten")
+		log.Info().Int("statusCode", r.StatusCode).Str("originalSessionId", originalSessionId).Str("fakeSessionId", s.config.IPUUID).Msg("session id rewritten")
 
 		r.Body = io.NopCloser(bytes.NewReader(body))
 		r.ContentLength = int64(len(body))
 		r.Header.Set("Content-Type", "application/json")
 		r.Header.Del("Content-Length")
 
-		log.Info().Str("sessionId", originalSessionId).Msg("session create response modified")
+		log.Info().Int("statusCode", r.StatusCode).Str("sessionId", originalSessionId).Msg("session create response modified")
 
 		return nil
 	}
@@ -214,7 +224,7 @@ func (s *Service) CreateSession(rw http.ResponseWriter, req *http.Request) {
 		proxy.WithTransport(transport),
 		proxy.WithRequestModifier(requestModifier),
 		proxy.WithResponseModifier(responseModifier),
-		proxy.WithErrorHandler(errorHandler),
+		proxy.WithErrorHandler(defaultErrorHandler),
 	)
 
 	rp.ServeHTTP(rw, req)
@@ -227,7 +237,7 @@ func (s *Service) ProxySession(rw http.ResponseWriter, req *http.Request) {
 	originalSessionId, ok := s.getSessionId(requestSessionId)
 	if !ok {
 		log.Err(errSessionNotFound).Msg("unknown sessionId")
-		writeErrorResponse(rw, http.StatusBadRequest, errSessionCreate)
+		writeErrorResponse(rw, http.StatusBadRequest, selenium.ErrInvalidSessionId(errSessionNotFound))
 		return
 	}
 
@@ -239,7 +249,7 @@ func (s *Service) ProxySession(rw http.ResponseWriter, req *http.Request) {
 		resolver := func(r *http.Request) (*url.URL, error) {
 			url := &url.URL{
 				Scheme: "ws",
-				Host:   net.JoinHostPort(localHost, s.config.BrowserPort),
+				Host:   net.JoinHostPort(loopbackAddr, s.config.BrowserPort),
 				Path: pathutils.Replace(req.URL.Path, map[string]string{
 					s.config.IPUUID: originalSessionId,
 				}),
@@ -312,7 +322,7 @@ func (s *Service) ProxySession(rw http.ResponseWriter, req *http.Request) {
 
 		r.URL = &url.URL{
 			Scheme: "http",
-			Host:   net.JoinHostPort(localHost, s.config.BrowserPort),
+			Host:   net.JoinHostPort(loopbackAddr, s.config.BrowserPort),
 			Path: pathutils.Replace(req.URL.Path, map[string]string{
 				s.config.IPUUID: originalSessionId,
 			}),
@@ -347,7 +357,7 @@ func (s *Service) ProxySession(rw http.ResponseWriter, req *http.Request) {
 			r.Body = io.NopCloser(bytes.NewReader(body))
 		}
 
-		log.Info().Str("sessionId", originalSessionId).Msg("session proxy response modified")
+		log.Info().Int("statusCode", r.StatusCode).Str("sessionId", originalSessionId).Msg("session proxy response modified")
 
 		return nil
 	}
@@ -355,7 +365,7 @@ func (s *Service) ProxySession(rw http.ResponseWriter, req *http.Request) {
 	rp := proxy.NewHTTPReverseProxy(
 		proxy.WithRequestModifier(reqModifier),
 		proxy.WithResponseModifier(responseModifier),
-		proxy.WithErrorHandler(errorHandler),
+		proxy.WithErrorHandler(defaultErrorHandler),
 	)
 
 	rp.ServeHTTP(rw, req)
@@ -387,7 +397,7 @@ func (s *Service) ProxyPlaywright(rw http.ResponseWriter, req *http.Request) {
 	resolver := func(r *http.Request) (*url.URL, error) {
 		url := &url.URL{
 			Scheme: "ws",
-			Host:   net.JoinHostPort(localHost, s.config.BrowserPort),
+			Host:   net.JoinHostPort(loopbackAddr, s.config.BrowserPort),
 			Path:   "/",
 		}
 		return url, nil
@@ -413,6 +423,134 @@ func (s *Service) ProxyPlaywright(rw http.ResponseWriter, req *http.Request) {
 
 	retryDialer := proxy.WithRetryTimeout(s.config.SessionCreateTimeout)
 	rp := proxy.NewWebSocketReverseProxy(resolver, onConnect, onMessage, onClose, retryDialer)
+	rp.ServeHTTP(rw, req)
+}
+
+func (s *Service) ProxyMcp(rw http.ResponseWriter, req *http.Request) {
+	log := logctx.FromContext(req.Context())
+
+	sessionId := req.Header.Get("Mcp-Session-Id")
+	if sessionId == "" && req.Method == http.MethodPost {
+
+		if s.store.Len() > 0 {
+			log.Err(errSessionCreate).Msg("mcp session already started")
+			jsonrpc.WriteError(rw, http.StatusBadRequest, jsonrpc.InvalidRequest, "Invalid Request: Server already initialized")
+			return
+		}
+
+		s.manager.Touch(s.config.IPUUID)
+
+		url := &url.URL{
+			Scheme:   "http",
+			Host:     net.JoinHostPort(loopbackAddr, s.config.BrowserPort),
+			Path:     req.URL.Path,
+			RawQuery: req.URL.RawQuery,
+		}
+
+		if err := wait(url.String(), s.config.SessionCreateTimeout); err != nil {
+			log.Err(err).Msg("browser service unavailable")
+			jsonrpc.WriteError(rw, http.StatusServiceUnavailable, jsonrpc.InternalError, "Internal error: browser mcp server unavailable")
+			return
+		}
+
+		reqModifier := func(r *http.Request) {
+			r.URL = url
+			r.Host = net.JoinHostPort(localhost, s.config.BrowserPort)
+			log.Info().Msg("mcp session create request modified")
+		}
+
+		respModifier := func(r *http.Response) error {
+			if r.StatusCode != http.StatusOK && r.StatusCode != http.StatusCreated {
+				log.Err(errSessionCreate).Int("statusCode", r.StatusCode).Msg("unexpected status code, mcp session not created")
+				notifyError(s.broadcaster, "unexpected status code", errSessionCreate)
+				return errSessionCreate
+			}
+
+			sessionId := s.config.IPUUID
+			if mcpSessionId := r.Header.Get("Mcp-Session-Id"); mcpSessionId != "" {
+				sessionId = mcpSessionId
+			}
+
+			s.storeSessionId(sessionId)
+
+			r.Header.Set("Mcp-Session-Id", s.config.IPUUID)
+			log.Info().Int("statusCode", r.StatusCode).Msg("mcp session create response modified")
+			return nil
+		}
+
+		transport := &retryTransport{
+			MaxRetries: s.config.SessionRetryCount,
+			Delay:      s.config.SessionRetryDelay,
+		}
+
+		rp := proxy.NewHTTPReverseProxy(
+			proxy.WithTransport(transport),
+			proxy.WithRequestModifier(reqModifier),
+			proxy.WithResponseModifier(respModifier),
+			proxy.WithErrorHandler(mcpErrorHandler),
+		)
+
+		rp.ServeHTTP(rw, req)
+		return
+	}
+
+	if sessionId == "" {
+		log.Err(errSessionNotFound).Msg("missing Mcp-Session-Id header")
+		jsonrpc.WriteError(rw, http.StatusBadRequest, jsonrpc.InvalidParams, "Bad Request: Mcp-Session-Id header is required")
+		return
+	}
+
+	if sessionId != s.config.IPUUID {
+		log.Err(errSessionNotFound).Str("sessionId", sessionId).Msg("unknown mcp sessionId")
+		jsonrpc.WriteError(rw, http.StatusNotFound, jsonrpc.SessionNotFound, "Session not found")
+		return
+	}
+
+	originalSessionId, ok := s.getSessionId(sessionId)
+	if !ok {
+		log.Err(errSessionNotFound).Str("sessionId", sessionId).Msg("mcp sessionId not found")
+		jsonrpc.WriteError(rw, http.StatusNotFound, jsonrpc.SessionNotFound, "Session not found")
+		return
+	}
+
+	s.manager.Touch(s.config.IPUUID)
+
+	log.Info().Str("sessionId", sessionId).Msg("proxying mcp request")
+
+	reqModifier := func(r *http.Request) {
+		if req.Method == http.MethodDelete {
+			time.AfterFunc(defaultSleepTimeout, func() {
+				notifyDelete(s.broadcaster, "delete browser")
+				log.Info().Str("sessionId", sessionId).Msg("mcp session deleted")
+			})
+		}
+
+		r.Header.Set("Mcp-Session-Id", originalSessionId)
+		if sessionId == originalSessionId {
+			r.Header.Del("Mcp-Session-Id")
+		}
+
+		r.URL = &url.URL{
+			Scheme:   "http",
+			Host:     net.JoinHostPort(loopbackAddr, s.config.BrowserPort),
+			Path:     "/mcp",
+			RawQuery: req.URL.RawQuery,
+		}
+		r.Host = net.JoinHostPort(localhost, s.config.BrowserPort)
+		log.Info().Str("sessionId", sessionId).Msg("mcp request modified")
+	}
+
+	respModifier := func(r *http.Response) error {
+		r.Header.Set("Mcp-Session-Id", s.config.IPUUID)
+		log.Info().Int("statusCode", r.StatusCode).Str("sessionId", sessionId).Msg("mcp response modified")
+		return nil
+	}
+
+	rp := proxy.NewHTTPReverseProxy(
+		proxy.WithRequestModifier(reqModifier),
+		proxy.WithResponseModifier(respModifier),
+		proxy.WithErrorHandler(mcpErrorHandler),
+	)
 	rp.ServeHTTP(rw, req)
 }
 
@@ -503,7 +641,7 @@ func (s *Service) RouteVNC(rw http.ResponseWriter, req *http.Request) {
 	}
 	defer wsconn.Close()
 
-	addr := net.JoinHostPort(localHost, "5900")
+	addr := net.JoinHostPort(loopbackAddr, "5900")
 	conn, err := dialTCP("tcp", addr)
 	if err != nil {
 		log.Err(err).Msg("vnc tcp connection failed")
@@ -598,10 +736,8 @@ func (s *Service) getSessionId(key string) (string, bool) {
 	return str, ok
 }
 
-func writeErrorResponse(rw http.ResponseWriter, status int, err error) {
-	rw.Header().Set("Content-Type", "application/json")
-	rw.WriteHeader(status)
-	json.NewEncoder(rw).Encode(map[string]string{"error": err.Error()})
+func writeErrorResponse(rw http.ResponseWriter, status int, err *selenium.SeleniumError) {
+	selenium.WriteError(rw, status, err)
 }
 
 func notifyError(broadcaster broadcast.Broadcaster[Event], source string, err error) {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -436,6 +436,417 @@ func TestProxySessionUnknownSession(t *testing.T) {
 	}
 }
 
+func TestProxyMcpMissingSessionId(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	svc := NewService(ServiceConfig{IPUUID: "fake"}, st, session.NewManager(time.Second, nil), &fakeBroadcaster{})
+
+	req := newRequestWithParams(http.MethodGet, "/mcp/", nil, map[string]string{}, "")
+	rw := httptestRecorder()
+
+	svc.ProxyMcp(rw, req)
+
+	assertMcpError(t, rw, http.StatusBadRequest, -32602)
+}
+
+func TestProxyMcpUnknownSessionId(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	svc := NewService(ServiceConfig{IPUUID: "fake"}, st, session.NewManager(time.Second, nil), &fakeBroadcaster{})
+
+	req := newRequestWithParams(http.MethodPost, "/mcp/other", nil, map[string]string{}, "")
+	req.Header.Set("Mcp-Session-Id", "other")
+	rw := httptestRecorder()
+
+	svc.ProxyMcp(rw, req)
+
+	assertMcpError(t, rw, http.StatusNotFound, -32001)
+}
+
+func TestProxyMcpSessionNotInStore(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	svc := NewService(ServiceConfig{IPUUID: "fake"}, st, session.NewManager(time.Second, nil), &fakeBroadcaster{})
+
+	req := newRequestWithParams(http.MethodGet, "/mcp/fake", nil, map[string]string{}, "")
+	req.Header.Set("Mcp-Session-Id", "fake")
+	rw := httptestRecorder()
+
+	svc.ProxyMcp(rw, req)
+
+	assertMcpError(t, rw, http.StatusNotFound, -32001)
+}
+
+func TestProxyMcpPostToMcp(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	cfg := ServiceConfig{IPUUID: "fake", BrowserPort: "4444", SessionCreateTimeout: 100 * time.Millisecond}
+	svc := NewService(cfg, st, session.NewManager(time.Second, nil), &fakeBroadcaster{})
+
+	var gotReq *http.Request
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodHead {
+			return response(http.StatusOK, ""), nil
+		}
+		gotReq = req
+		return response(http.StatusOK, `{"jsonrpc":"2.0","id":1,"result":{}}`), nil
+	})
+
+	withDefaultTransports(t, rt, func() {
+		req := newRequestWithParams(http.MethodPost, "/mcp", bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`), nil, "")
+		rw := httptestRecorder()
+
+		svc.ProxyMcp(rw, req)
+
+		if gotReq == nil {
+			t.Fatal("expected request to reach transport")
+		}
+		if gotReq.URL.Path != "/mcp" {
+			t.Fatalf("expected path /mcp, got %s", gotReq.URL.Path)
+		}
+		if !strings.Contains(gotReq.Host, "localhost") {
+			t.Fatalf("expected Host header with localhost, got %s", gotReq.Host)
+		}
+	})
+}
+
+func TestProxyMcpGetToMcp(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	st.Set("fake", "orig")
+	cfg := ServiceConfig{IPUUID: "fake", BrowserPort: "4444"}
+	svc := NewService(cfg, st, session.NewManager(time.Second, nil), &fakeBroadcaster{})
+
+	var gotReq *http.Request
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotReq = req
+		return response(http.StatusOK, "{}"), nil
+	})
+
+	withProxyTransport(t, rt, func() {
+		req := newRequestWithParams(http.MethodGet, "/mcp/fake", nil, map[string]string{}, "")
+		req.Header.Set("Mcp-Session-Id", "fake")
+		rw := httptestRecorder()
+
+		svc.ProxyMcp(rw, req)
+
+		if gotReq == nil {
+			t.Fatal("expected request to reach transport")
+		}
+		if gotReq.URL.Path != "/mcp" {
+			t.Fatalf("expected path /mcp, got %s", gotReq.URL.Path)
+		}
+	})
+}
+
+func TestProxyMcpPreservesQueryParams(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	cfg := ServiceConfig{IPUUID: "fake", BrowserPort: "4444", SessionCreateTimeout: 100 * time.Millisecond}
+	svc := NewService(cfg, st, session.NewManager(time.Second, nil), &fakeBroadcaster{})
+
+	var gotReq *http.Request
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodHead {
+			return response(http.StatusOK, ""), nil
+		}
+		gotReq = req
+		return response(http.StatusOK, "{}"), nil
+	})
+
+	withDefaultTransports(t, rt, func() {
+		req := newRequestWithParams(http.MethodPost, "/mcp/fake?foo=bar&baz=qux", nil, map[string]string{"sessionId": "fake"}, "")
+		rw := httptestRecorder()
+
+		svc.ProxyMcp(rw, req)
+
+		if gotReq == nil {
+			t.Fatal("expected request to reach transport")
+		}
+		if gotReq.URL.RawQuery != "foo=bar&baz=qux" {
+			t.Fatalf("expected query params preserved, got %q", gotReq.URL.RawQuery)
+		}
+	})
+}
+
+func TestProxyMcpStoresSessionWhenMissing(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	cfg := ServiceConfig{IPUUID: "fake", BrowserPort: "4444", SessionCreateTimeout: 100 * time.Millisecond}
+	svc := NewService(cfg, st, session.NewManager(time.Second, nil), &fakeBroadcaster{})
+
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodHead {
+			return response(http.StatusOK, ""), nil
+		}
+		resp := response(http.StatusOK, "{}")
+		resp.Header.Set("Mcp-Session-Id", "real-session")
+		return resp, nil
+	})
+
+	withDefaultTransports(t, rt, func() {
+		req := newRequestWithParams(http.MethodPost, "/mcp/fake", nil, map[string]string{"sessionId": "fake"}, "")
+		rw := httptestRecorder()
+
+		svc.ProxyMcp(rw, req)
+
+		if got, ok := st.Get("fake"); !ok || got != "real-session" {
+			t.Fatalf("expected store mapping fake->real-session, got %v (ok=%v)", got, ok)
+		}
+		if rw.Header().Get("Mcp-Session-Id") != "fake" {
+			t.Fatalf("expected response Mcp-Session-Id rewritten to fake, got %q", rw.Header().Get("Mcp-Session-Id"))
+		}
+	})
+}
+
+func TestProxyMcpKeepsExistingSession(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	st.Set("fake", "orig")
+	cfg := ServiceConfig{IPUUID: "fake", BrowserPort: "4444"}
+	svc := NewService(cfg, st, session.NewManager(time.Second, nil), &fakeBroadcaster{})
+
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return response(http.StatusOK, "{}"), nil
+	})
+
+	withProxyTransport(t, rt, func() {
+		req := newRequestWithParams(http.MethodPost, "/mcp/fake", nil, map[string]string{"sessionId": "fake"}, "")
+		rw := httptestRecorder()
+
+		svc.ProxyMcp(rw, req)
+
+		if got, ok := st.Get("fake"); !ok || got != "orig" {
+			t.Fatalf("expected existing mapping fake->orig, got %v (ok=%v)", got, ok)
+		}
+	})
+}
+
+func TestProxyMcpRewritesRequestSessionId(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	st.Set("fake", "orig")
+	cfg := ServiceConfig{IPUUID: "fake", BrowserPort: "4444"}
+	svc := NewService(cfg, st, session.NewManager(time.Second, nil), &fakeBroadcaster{})
+
+	var gotReq *http.Request
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotReq = req
+		return response(http.StatusOK, "{}"), nil
+	})
+
+	withProxyTransport(t, rt, func() {
+		req := newRequestWithParams(http.MethodPost, "/mcp/fake", nil, map[string]string{}, "")
+		req.Header.Set("Mcp-Session-Id", "fake")
+		req.Header.Set("Content-Type", "application/json")
+		rw := httptestRecorder()
+
+		svc.ProxyMcp(rw, req)
+
+		if gotReq == nil {
+			t.Fatal("expected request to reach transport")
+		}
+		if gotReq.Header.Get("Mcp-Session-Id") != "orig" {
+			t.Fatalf("expected Mcp-Session-Id rewritten to orig, got %q", gotReq.Header.Get("Mcp-Session-Id"))
+		}
+		if gotReq.Header.Get("Content-Type") != "application/json" {
+			t.Fatalf("expected Content-Type preserved, got %q", gotReq.Header.Get("Content-Type"))
+		}
+	})
+}
+
+func TestProxyMcpRewritesResponseSessionId(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	st.Set("fake", "orig")
+	cfg := ServiceConfig{IPUUID: "fake", BrowserPort: "4444"}
+	svc := NewService(cfg, st, session.NewManager(time.Second, nil), &fakeBroadcaster{})
+
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		resp := response(http.StatusOK, "{}")
+		resp.Header.Set("Mcp-Session-Id", "orig")
+		return resp, nil
+	})
+
+	withProxyTransport(t, rt, func() {
+		req := newRequestWithParams(http.MethodPost, "/mcp/fake", nil, map[string]string{}, "")
+		req.Header.Set("Mcp-Session-Id", "fake")
+		rw := httptestRecorder()
+
+		svc.ProxyMcp(rw, req)
+
+		if rw.Header().Get("Mcp-Session-Id") != "fake" {
+			t.Fatalf("expected response Mcp-Session-Id rewritten to fake, got %q", rw.Header().Get("Mcp-Session-Id"))
+		}
+	})
+}
+
+func TestProxyMcpDeleteNotifiesDelete(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	st.Set("fake", "orig")
+	cfg := ServiceConfig{IPUUID: "fake", BrowserPort: "4444"}
+	rec := &fakeBroadcaster{}
+	svc := NewService(cfg, st, session.NewManager(time.Second, nil), rec)
+
+	var gotReq *http.Request
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotReq = req
+		return response(http.StatusOK, "{}"), nil
+	})
+
+	withProxyTransport(t, rt, func() {
+		req := newRequestWithParams(http.MethodDelete, "/mcp/fake", nil, map[string]string{}, "")
+		req.Header.Set("Mcp-Session-Id", "fake")
+		rw := httptestRecorder()
+
+		svc.ProxyMcp(rw, req)
+
+		if gotReq == nil {
+			t.Fatal("expected request to reach transport")
+		}
+		if gotReq.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE method, got %s", gotReq.Method)
+		}
+		if gotReq.URL.Path != "/mcp" {
+			t.Fatalf("expected path /mcp, got %s", gotReq.URL.Path)
+		}
+
+		time.Sleep(defaultSleepTimeout + 500*time.Millisecond)
+
+		rec.mu.Lock()
+		defer rec.mu.Unlock()
+		found := false
+		for _, e := range rec.events {
+			if e.Type == EventTypeDeleted {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatal("expected EventTypeDeleted to be broadcast after DELETE")
+		}
+	})
+}
+
+func TestProxyMcpDeleteDoesNotNotifyOnOtherMethods(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	cfg := ServiceConfig{IPUUID: "fake", BrowserPort: "4444"}
+	rec := &fakeBroadcaster{}
+	svc := NewService(cfg, st, session.NewManager(time.Second, nil), rec)
+
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return response(http.StatusOK, "{}"), nil
+	})
+
+	withProxyTransport(t, rt, func() {
+		req := newRequestWithParams(http.MethodPost, "/mcp/fake", nil, map[string]string{"sessionId": "fake"}, "")
+		rw := httptestRecorder()
+
+		svc.ProxyMcp(rw, req)
+
+		time.Sleep(defaultSleepTimeout + 500*time.Millisecond)
+
+		rec.mu.Lock()
+		defer rec.mu.Unlock()
+		for _, e := range rec.events {
+			if e.Type == EventTypeDeleted {
+				t.Fatal("unexpected EventTypeDeleted for POST request")
+			}
+		}
+	})
+}
+
+func TestProxyMcpInitUnexpectedStatus(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	cfg := ServiceConfig{IPUUID: "fake", BrowserPort: "4444", SessionCreateTimeout: 100 * time.Millisecond}
+	svc := NewService(cfg, st, session.NewManager(time.Second, nil), &fakeBroadcaster{})
+
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodHead {
+			return response(http.StatusOK, ""), nil
+		}
+		return response(http.StatusInternalServerError, "boom"), nil
+	})
+
+	withDefaultTransports(t, rt, func() {
+		req := newRequestWithParams(http.MethodPost, "/mcp/", bytes.NewBufferString(`{}`), map[string]string{}, "")
+		rw := httptestRecorder()
+
+		svc.ProxyMcp(rw, req)
+
+		assertMcpError(t, rw, http.StatusInternalServerError, -32603)
+		if _, ok := st.Get("fake"); ok {
+			t.Fatal("expected no session stored on failed init")
+		}
+	})
+}
+
+func TestProxyMcpInitWaitTimeout(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	cfg := ServiceConfig{IPUUID: "fake", BrowserPort: "4444", SessionCreateTimeout: 20 * time.Millisecond}
+	svc := NewService(cfg, st, session.NewManager(time.Second, nil), &fakeBroadcaster{})
+
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("connection refused")
+	})
+
+	withDefaultTransports(t, rt, func() {
+		req := newRequestWithParams(http.MethodPost, "/mcp/", bytes.NewBufferString(`{}`), map[string]string{}, "")
+		rw := httptestRecorder()
+
+		svc.ProxyMcp(rw, req)
+
+		assertMcpError(t, rw, http.StatusServiceUnavailable, -32603)
+		if _, ok := st.Get("fake"); ok {
+			t.Fatal("expected no session stored on wait timeout")
+		}
+	})
+}
+
+func TestProxyMcpAlreadyStarted(t *testing.T) {
+	st := store.NewDefaultStore[string]()
+	st.Set("fake", "orig")
+	svc := NewService(ServiceConfig{IPUUID: "fake"}, st, session.NewManager(time.Second, nil), &fakeBroadcaster{})
+
+	req := newRequestWithParams(http.MethodPost, "/mcp", bytes.NewBufferString(`{}`), nil, "")
+	rw := httptestRecorder()
+
+	svc.ProxyMcp(rw, req)
+
+	assertMcpError(t, rw, http.StatusBadRequest, -32600)
+}
+
+func TestMcpErrorHandler(t *testing.T) {
+	rw := httptestRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	mcpErrorHandler(rw, req, errors.New("boom"))
+
+	assertMcpError(t, rw, http.StatusInternalServerError, -32603)
+}
+
+func assertMcpError(t *testing.T, rw *recorder, wantStatus, wantCode int) {
+	t.Helper()
+	if rw.status != wantStatus {
+		t.Fatalf("expected status %d, got %d", wantStatus, rw.status)
+	}
+	if ct := rw.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected Content-Type application/json, got %q", ct)
+	}
+	var body struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      any    `json:"id"`
+		Error   struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rw.body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode JSON-RPC error body %q: %v", rw.body.String(), err)
+	}
+	if body.JSONRPC != "2.0" {
+		t.Fatalf("expected jsonrpc 2.0, got %q", body.JSONRPC)
+	}
+	if body.ID != nil {
+		t.Fatalf("expected id null, got %v", body.ID)
+	}
+	if body.Error.Code != wantCode {
+		t.Fatalf("expected error code %d, got %d", wantCode, body.Error.Code)
+	}
+	if body.Error.Message == "" {
+		t.Fatal("expected non-empty error message")
+	}
+}
+
 func TestRouteHTTPMissingSessionId(t *testing.T) {
 	st := store.NewDefaultStore[string]()
 	svc := NewService(ServiceConfig{}, st, session.NewManager(time.Second, nil), &fakeBroadcaster{})
@@ -674,7 +1085,7 @@ func TestStoreSessionIdAndGetSessionId(t *testing.T) {
 
 func TestWriteErrorResponse(t *testing.T) {
 	rw := httptestRecorder()
-	writeErrorResponse(rw, http.StatusBadRequest, errors.New("bad"))
+	writeErrorResponse(rw, http.StatusBadRequest, selenium.ErrSessionNotCreated(errors.New("bad")))
 
 	if rw.status != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", rw.status)
@@ -682,8 +1093,16 @@ func TestWriteErrorResponse(t *testing.T) {
 	if got := rw.header.Get("Content-Type"); got != "application/json" {
 		t.Fatalf("expected Content-Type application/json, got %q", got)
 	}
-	if rw.body.Len() == 0 {
-		t.Fatal("expected non-empty response body")
+
+	var body selenium.SeleniumError
+	if err := json.Unmarshal(rw.body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode body %q: %v", rw.body.String(), err)
+	}
+	if body.Value.Name != "session not created" {
+		t.Fatalf("expected error name 'session not created', got %q", body.Value.Name)
+	}
+	if !strings.Contains(body.Value.Message, "bad") {
+		t.Fatalf("expected message to contain root cause, got %q", body.Value.Message)
 	}
 }
 
@@ -730,7 +1149,7 @@ func TestProxySessionHTTP(t *testing.T) {
 		if gotReq == nil {
 			t.Fatal("expected request to reach transport")
 		}
-		if !strings.Contains(gotReq.URL.Host, "localhost") {
+		if !strings.Contains(gotReq.URL.Host, "127.0.0.1") {
 			t.Fatalf("unexpected host: %s", gotReq.URL.Host)
 		}
 		if !strings.Contains(gotReq.URL.Path, "orig") {


### PR DESCRIPTION
  ## Changes

  **MCP proxy (`ProxyMcp`, `cmd/seleniferous/main.go`)**
  - Route `/mcp` (`POST`/`GET`/`DELETE`) behind the session-create timeout
    middleware.
  - **Initialize** (header-less `POST`): rejects a second session
    (JSON-RPC *"Server already initialized"*), **waits for the in-pod MCP server
    to be ready** via an HTTP `HEAD` poll + retrying transport (prevents
    connection-refused retry storms), proxies the create, stores the
    `IPUUID → session` mapping, and rewrites `Mcp-Session-Id` to the stable pod
    UUID.
  - **Subsequent requests**: resolve the session from `Mcp-Session-Id`; missing
    header → `InvalidParams`; unknown/expired session → **404 `SessionNotFound`**
    so the client re-initializes.

  **Error responses** 
  - MCP errors emitted as **JSON-RPC 2.0** via the shared selenosis `pkg/jsonrpc`
    (`InvalidRequest` / `InvalidParams` / `InternalError` / `SessionNotFound`) —
    codes unified with the hub.
  - WebDriver errors switched from a flat `{"error":...}` body to the **W3C**
    shape via `selenium.WriteError`; `writeErrorResponse` now takes
    `*selenium.SeleniumError` and all create/proxy branches map to
    `selenium.Err*` constructors.
  - Shared `defaultErrorHandler` (Selenium) and `mcpErrorHandler` (MCP) proxy
    error handlers.
  
  **Logging**
  - `statusCode` added to session-create, proxy, and MCP response logs.

  **Dependencies**
  - `browser-controller` v0.0.6 → **v0.0.8**
  - `browser-service` v0.0.6 → **v0.0.7**
  - `selenosis/v2` v2.0.6 → **v2.0.8** (brings shared `pkg/jsonrpc` and
    `selenium.WriteError`

  ## Compatibility
  - **Behavior change:** seleniferous-originated WebDriver error bodies are now
    W3C-shaped (`{"value":{"error","message"}}`) instead of flat `{"error":...}`.
  - `/mcp` is a new endpoint; existing WebDriver/Playwright flows are unchanged.