### PR TITLE
Log hub instance + renamed request-id header in sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ ends or goes idle.
 [![Go Reference](https://pkg.go.dev/badge/github.com/alcounit/seleniferous.svg)](https://pkg.go.dev/github.com/alcounit/seleniferous/v2)
 [![Docker Pulls](https://img.shields.io/docker/pulls/alcounit/seleniferous.svg)](https://hub.docker.com/r/alcounit/seleniferous)
 [![codecov](https://codecov.io/gh/alcounit/seleniferous/branch/main/graph/badge.svg)](https://codecov.io/gh/alcounit/seleniferous)
-[![Go Report Card](https://goreportcard.com/badge/github.com/alcounit/seleniferous/v2)](https://goreportcard.com/report/github.com/alcounit/seleniferous/v2)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 
 ---

--- a/cmd/seleniferous/main.go
+++ b/cmd/seleniferous/main.go
@@ -47,25 +47,14 @@ func main() {
 	store := store.NewDefaultStore[string]()
 	svc := service.NewService(cfg, store, mgr, broadcaster)
 
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to resolve hostname, using fallback")
+		hostname = "unknown"
+	}
+
 	router := chi.NewRouter()
-	router.Use(func(next http.Handler) http.Handler {
-		fn := func(rw http.ResponseWriter, req *http.Request) {
-
-			selenosisReqId := req.Header.Get("Selenosis-Request-ID")
-			logger := log.With().
-				Str("method", req.Method).
-				Str("path", req.URL.Path).
-				Str("reqId", uuid.NewString()).
-				Str("selenosisReqId", selenosisReqId).
-				Logger()
-
-			ctx := req.Context()
-			ctx = logctx.IntoContext(ctx, logger)
-
-			next.ServeHTTP(rw, req.WithContext(ctx))
-		}
-		return http.HandlerFunc(fn)
-	})
+	router.Use(requestContextMiddleware(log, hostname))
 
 	createTimeoutMiddleWare := waitFirstRequest(cfg.SessionCreateTimeout, func() {
 		broadcaster.Broadcast(sessionCreateTimeout())
@@ -234,5 +223,29 @@ func waitFirstRequest(deadline time.Duration, onTimeout func()) func(next http.H
 
 			next.ServeHTTP(w, r)
 		})
+	}
+}
+
+func requestContextMiddleware(logger zerolog.Logger, hostname string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(rw http.ResponseWriter, req *http.Request) {
+
+			selenosisReqId := req.Header.Get("X-Selenosis-Request-ID")
+			selenosisHost := req.Header.Get("X-Selenosis-Hostname")
+			l := logger.With().
+				Str("method", req.Method).
+				Str("path", req.URL.Path).
+				Str("reqId", uuid.NewString()).
+				Str("selenosisReqId", selenosisReqId).
+				Str("selenosisHost", selenosisHost).
+				Str("hostname", hostname).
+				Logger()
+
+			ctx := req.Context()
+			ctx = logctx.IntoContext(ctx, l)
+
+			next.ServeHTTP(rw, req.WithContext(ctx))
+		}
+		return http.HandlerFunc(fn)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 require github.com/gorilla/websocket v1.5.3
 
 require (
-	github.com/alcounit/browser-controller v0.0.8
-	github.com/alcounit/browser-service v0.0.7
+	github.com/alcounit/browser-controller v0.0.9
+	github.com/alcounit/browser-service v0.0.8
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/google/uuid v1.6.0
 	github.com/rs/zerolog v1.34.0
@@ -14,7 +14,7 @@ require (
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
-	github.com/alcounit/selenosis/v2 v2.0.8
+	github.com/alcounit/selenosis/v2 v2.0.9
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	golang.org/x/sys v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
-github.com/alcounit/browser-controller v0.0.8 h1:hauzkisDiUsGoIKUoQqvBmi4/MrixzGp55PnZIUA6rY=
-github.com/alcounit/browser-controller v0.0.8/go.mod h1:tpj7lwi2UJ49xt/vnEsZKAu5HAvtQJ7xbbcJO3wn+dc=
-github.com/alcounit/browser-service v0.0.7 h1:Pv33j3QrtjZaa4QxoohzCGn1urJ20kiMLgDwKeg1y1Q=
-github.com/alcounit/browser-service v0.0.7/go.mod h1:Oozpap9DWLAu2ViuJua5Q9KHXziVZUUFhacC//SVlXw=
-github.com/alcounit/selenosis/v2 v2.0.8 h1:vv2oM1diZB78xdNzpd1w2zrzfeBQc7GyzCGD0e20ats=
-github.com/alcounit/selenosis/v2 v2.0.8/go.mod h1:1hiSF5IDj9Zh7PuOetmk3+W6m9KJQbFp1FFzwfi/e2k=
+github.com/alcounit/browser-controller v0.0.9 h1:Z10ryX+/QrgV+kB/Y+WT0WIsigcB2cPS9RVv7V/auSg=
+github.com/alcounit/browser-controller v0.0.9/go.mod h1:tpj7lwi2UJ49xt/vnEsZKAu5HAvtQJ7xbbcJO3wn+dc=
+github.com/alcounit/browser-service v0.0.8 h1:9qn7oRrsmz1/E31gnPKXwSDArbZf3k4ts8fWTBoz0Jg=
+github.com/alcounit/browser-service v0.0.8/go.mod h1:SzJ5hMhNJh6McA3cl3oceJjNqLCjNcqBT8tEnPuxniI=
+github.com/alcounit/selenosis/v2 v2.0.9 h1:VEmPXYPN0UPRqE9s/lycjZFFgUep8KGb2+/C9gdbRHo=
+github.com/alcounit/selenosis/v2 v2.0.9/go.mod h1:8Dc8fXWpaIHzrU6JUvtyx6XmCvdPkf9b/drRC3SZdgw=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
 github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=


### PR DESCRIPTION
Sidecar now logs which selenosis hub instance and request each call came from, and adopts the renamed X-Selenosis-Request-ID header.